### PR TITLE
ESP8266 - Internal clock needs to be set for certificate verification

### DIFF
--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -116,14 +116,12 @@ class ConnectionHandler {
 #if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266)
   #ifdef ARDUINO_ESP8266_ESP12
     #include <ESP8266WiFi.h>
-
   #else
     #include <WiFi.h>
   #endif
 
   #include <WiFiUdp.h>
   #define BOARD_HAS_WIFI
-  #define GETTIME_MISSING
   #define NETWORK_HARDWARE_ERROR WL_NO_SHIELD
   #define NETWORK_IDLE_STATUS WL_IDLE_STATUS
   #define NETWORK_CONNECTED WL_CONNECTED

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -91,11 +91,11 @@ void WiFiConnectionHandler::execNetworkEventCallback(OnNetworkEventCallback & ca
 }
 
 unsigned long WiFiConnectionHandler::getTime() {
-  #ifdef GETTIME_MISSING
-  return 0;
-  #else
+#if !defined(ARDUINO_ESP8266_ESP12) && !defined(ARDUINO_ARCH_ESP32) && !defined(ESP8266)
   return WiFi.getTime();
-  #endif
+#else
+  return 0;
+#endif
 }
 
 void WiFiConnectionHandler::update() {
@@ -158,7 +158,7 @@ void WiFiConnectionHandler::update() {
             return;
           } else {
             Debug.print(DBG_INFO, "Connected to \"%s\"", ssid);
-            changeConnectionState(NetworkConnectionState::CONNECTED);
+            changeConnectionState(NetworkConnectionState::GETTIME);
             return;
           }
         }
@@ -175,7 +175,11 @@ void WiFiConnectionHandler::update() {
         }
         break;
       case NetworkConnectionState::GETTIME: {
-
+#if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266)
+        configTime(0, 0, "pool.ntp.org", "time.nist.gov");
+        changeConnectionState(NetworkConnectionState::CONNECTED);
+        Debug.print(DBG_VERBOSE, "NetworkConnectionState::GETTIME");
+#endif
         }
         break;
       case NetworkConnectionState::DISCONNECTING: {

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -175,11 +175,11 @@ void WiFiConnectionHandler::update() {
         }
         break;
       case NetworkConnectionState::GETTIME: {
+        Debug.print(DBG_VERBOSE, "NetworkConnectionState::GETTIME");
 #if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266)
         configTime(0, 0, "pool.ntp.org", "time.nist.gov");
-        changeConnectionState(NetworkConnectionState::CONNECTED);
-        Debug.print(DBG_VERBOSE, "NetworkConnectionState::GETTIME");
 #endif
+        changeConnectionState(NetworkConnectionState::CONNECTED);
         }
         break;
       case NetworkConnectionState::DISCONNECTING: {

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -177,7 +177,7 @@ void WiFiConnectionHandler::update() {
       case NetworkConnectionState::GETTIME: {
         Debug.print(DBG_VERBOSE, "NetworkConnectionState::GETTIME");
 #if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266)
-        configTime(0, 0, "pool.ntp.org", "time.nist.gov");
+        configTime(0, 0, "time.arduino.cc", "pool.ntp.org", "time.nist.gov");
 #endif
         changeConnectionState(NetworkConnectionState::CONNECTED);
         }


### PR DESCRIPTION
Internal ESP12 clock must be set in order to allow verification of certificate. This function just tasks the ESP framework with performing the NTP time sync, the time is not synched when this function returns. It may take a little while.

Necessary for https://github.com/arduino-libraries/ArduinoIoTCloud/pull/76