### PR TITLE
Adding support for all ESP8266 based boards currently supported by ESP8266 core

### DIFF
--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -113,14 +113,41 @@ class ConnectionHandler {
   #define NETWORK_CONNECTED GSM3_NetworkStatus_t::GPRS_READY
 #endif
 
-#if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266)
-  #if defined(ARDUINO_ESP8266_ESP12) || defined(ESP8266)
-    #include <ESP8266WiFi.h>
-  #else
-    #include <WiFi.h>
-  #endif
+#if    defined(ARDUINO_ESP8266_ESP12)    \
+    || defined(ESP8266)                  \
+    || defined(ESP8266_ESP01)            \
+    || defined(ESP8266_ESP13)            \
+    || defined(ESP8266_GENERIC)          \
+    || defined(ESP8266_ESPRESSO_LITE_V1) \
+    || defined(ESP8266_ESPRESSO_LITE_V2) \
+    || defined(ESP8266_PHOENIX_V1)       \
+    || defined(ESP8266_PHOENIX_V2)       \
+    || defined(ESP8266_NODEMCU)          \
+    || defined(MOD_WIFI_ESP8266)         \
+    || defined(ESP8266_THING)            \
+    || defined(ESP8266_THING_DEV)        \
+    || defined(ESP8266_ESP210)           \
+    || defined(ESP8266_WEMOS_D1MINI)     \
+    || defined(ESP8266_WEMOS_D1MINIPRO)  \
+    || defined(ESP8266_WEMOS_D1MINILITE) \
+    || defined(ESP8266_WEMOS_D1R1)       \
+    || defined(ESP8266_ESP12)            \
+    || defined(WIFINFO)                  \
+    || defined(ESP8266_ARDUINO)          \
+    || defined(GEN4_IOD)                 \
+    || defined(ESP8266_OAK)              \
+    || defined(WIFIDUINO_ESP8266)        \
+    || defined(AMPERKA_WIFI_SLOT)        \
+    || defined(ESP8266_WIO_LINK)         \
+    || defined(ESP8266_ESPECTRO_CORE)
+  
+  #define BOARD_ESP8266
+#endif
 
+#if defined(BOARD_ESP8266)
+  #include <ESP8266WiFi.h>
   #include <WiFiUdp.h>
+
   #define BOARD_HAS_WIFI
   #define NETWORK_HARDWARE_ERROR WL_NO_SHIELD
   #define NETWORK_IDLE_STATUS WL_IDLE_STATUS

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -91,7 +91,7 @@ void WiFiConnectionHandler::execNetworkEventCallback(OnNetworkEventCallback & ca
 }
 
 unsigned long WiFiConnectionHandler::getTime() {
-#if !defined(ARDUINO_ESP8266_ESP12) && !defined(ARDUINO_ARCH_ESP32) && !defined(ESP8266)
+#if !defined(BOARD_ESP8266)
   return WiFi.getTime();
 #else
   return 0;
@@ -109,7 +109,7 @@ void WiFiConnectionHandler::update() {
     switch (netConnectionState) {
       case NetworkConnectionState::INIT: {
           Debug.print(DBG_VERBOSE, "::INIT");
-          #if !defined(ARDUINO_ESP8266_ESP12) && !defined(ARDUINO_ARCH_ESP32) && !defined(ESP8266)
+          #if !defined(BOARD_ESP8266)
           networkStatus = WiFi.status();
 
           Debug.print(DBG_INFO, "WiFi.status(): %d", networkStatus);
@@ -139,7 +139,7 @@ void WiFiConnectionHandler::update() {
           Debug.print(DBG_VERBOSE, "::CONNECTING");
           networkStatus = WiFi.status();
 
-          #if !defined(ARDUINO_ESP8266_ESP12) && !defined(ARDUINO_ARCH_ESP32) &&  !defined(ESP8266)
+          #if !defined(BOARD_ESP8266)
 
           if (networkStatus != WL_CONNECTED) {
             networkStatus = WiFi.begin(ssid, pass);
@@ -177,7 +177,7 @@ void WiFiConnectionHandler::update() {
         break;
       case NetworkConnectionState::GETTIME: {
         Debug.print(DBG_VERBOSE, "NetworkConnectionState::GETTIME");
-#if defined(ARDUINO_ESP8266_ESP12) || defined(ARDUINO_ARCH_ESP32) || defined(ESP8266)
+#if defined(BOARD_ESP8266)
         configTime(0, 0, "time.arduino.cc", "pool.ntp.org", "time.nist.gov");
 #endif
         changeConnectionState(NetworkConnectionState::CONNECTED);
@@ -190,7 +190,7 @@ void WiFiConnectionHandler::update() {
         }
         break;
       case NetworkConnectionState::DISCONNECTED: {
-          #if !defined(ARDUINO_ESP8266_ESP12) && !defined(ARDUINO_ARCH_ESP32) && !defined(ESP8266)
+          #if !defined(BOARD_ESP8266)
           WiFi.end();
           #endif
           if (keepAlive) {
@@ -260,7 +260,7 @@ void WiFiConnectionHandler::changeConnectionState(NetworkConnectionState _newSta
       break;
     case NetworkConnectionState::CLOSED: {
 
-        #if !defined(ARDUINO_ESP8266_ESP12) && !defined(ARDUINO_ARCH_ESP32) &&  !defined(ESP8266)
+        #if !defined(BOARD_ESP8266)
         WiFi.end();
         #endif
 


### PR DESCRIPTION
This PR extends the code to verify if any of the currently by the ESP8266 core supported boards are compiled with this library and includes the appopriate header files.