### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Originally part of ArduinoIoTCloud
 category=Communication
 url=https://github.com/arduino-libraries/Arduino_ConnectionHandler
 architectures=samd,esp32,esp8266
+depends=Arduino_DebugUtils, WiFi101, WiFiNINA, MKRGSM


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format