### PR TITLE
NBConnectionHandler: fix constructor chaining

### DIFF
--- a/src/Arduino_NBConnectionHandler.cpp
+++ b/src/Arduino_NBConnectionHandler.cpp
@@ -41,19 +41,19 @@ static const unsigned long NETWORK_CONNECTION_INTERVAL = 30000;
 /******************************************************************************
    CTOR/DTOR
  ******************************************************************************/
-NBConnectionHandler::NBConnectionHandler(const char *pin, const char *apn, const char *login, const char *pass, bool _keepAlive) :
-  login(login),
-  pass(pass) {
-    NBConnectionHandler(pin, apn, _keepAlive);
+NBConnectionHandler::NBConnectionHandler(const char *pin, bool _keepAlive) :
+  NBConnectionHandler(pin, "", _keepAlive) {
 }
 
 NBConnectionHandler::NBConnectionHandler(const char *pin, const char *apn, bool _keepAlive) :
-  apn(apn) {
-    NBConnectionHandler(pin, _keepAlive);
+  NBConnectionHandler(pin, apn, "", "", _keepAlive) {
 }
 
-NBConnectionHandler::NBConnectionHandler(const char *pin, bool _keepAlive) :
+NBConnectionHandler::NBConnectionHandler(const char *pin, const char *apn, const char *login, const char *pass, bool _keepAlive) :
   pin(pin),
+  apn(apn),
+  login(login),
+  pass(pass),
   lastConnectionTickTime(millis()),
   connectionTickTimeInterval(CHECK_INTERVAL_IDLE),
   keepAlive(_keepAlive),


### PR DESCRIPTION
This pull request fixes issues with the long constructor added in https://github.com/arduino-libraries/Arduino_ConnectionHandler/pull/12.

It appears PR #12 was merged without testing, this is very bad.

cc/ @AlbyIanna