### PR TITLE
Add MKRNB to dependencies list

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Originally part of ArduinoIoTCloud
 category=Communication
 url=https://github.com/arduino-libraries/Arduino_ConnectionHandler
 architectures=samd,esp32,esp8266
-depends=Arduino_DebugUtils, WiFi101, WiFiNINA, MKRGSM
+depends=Arduino_DebugUtils, WiFi101, WiFiNINA, MKRGSM, MKRNB


### PR DESCRIPTION
The MKRNB library dependency was introduced with the MKR NB 1500 support (https://github.com/arduino-libraries/Arduino_ConnectionHandler/pull/7).