### PR TITLE
Use GitHub Actions for continuous integration tests

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,24 @@
+name: Compile Examples
+on: [push, pull_request]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+
+   strategy:
+     matrix:
+       fqbn: [
+         "arduino:samd:mkr1000",
+         "arduino:samd:mkrwifi1010",
+         "arduino:samd:nano_33_iot",
+         "arduino:samd:mkrgsm1400",
+         "arduino:samd:mkrnb1500"
+       ]
+
+   steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+     - uses: arduino/actions/libraries/compile-examples@master
+       with:
+         fqbn: ${{ matrix.fqbn }}
+         libraries: Arduino_DebugUtils WiFi101 WiFiNINA MKRGSM MKRNB

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,11 @@
+name: Spell Check
+on: [push, pull_request]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+
+   steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+     - uses: arduino/actions/libraries/spell-check@master


### PR DESCRIPTION
- Spell check all files.
- Compile all example sketches for the WiFi SAMD boards (Arduino currently has no established GitHub Actions mechanism to install the ESP8266 and ESP32 cores and the example isn't compatible with the non-WiFi boards the library supports).

Successful CI run: https://github.com/per1234/Arduino_ConnectionHandler/runs/383430744