### PR TITLE
Run compile-examples CI action for ESP8266 board

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -4,6 +4,8 @@ jobs:
  build:
    runs-on: ubuntu-latest
 
+   env:
+     LIBRARIES: Arduino_DebugUtils WiFi101 WiFiNINA MKRGSM MKRNB
    strategy:
      matrix:
        fqbn: [
@@ -11,14 +13,24 @@ jobs:
          "arduino:samd:mkrwifi1010",
          "arduino:samd:nano_33_iot",
          "arduino:samd:mkrgsm1400",
-         "arduino:samd:mkrnb1500"
+         "arduino:samd:mkrnb1500",
+         '"esp8266:esp8266:huzzah" "https://arduino.esp8266.com/stable/package_esp8266com_index.json"'
        ]
 
    steps:
      - uses: actions/checkout@v1
        with:
          fetch-depth: 1
-     - uses: arduino/actions/libraries/compile-examples@master
+     - name: compile-examples for official Arduino boards
+       if: startsWith(matrix.fqbn, '"esp8266:esp8266') != true
+       uses: arduino/actions/libraries/compile-examples@master
        with:
          fqbn: ${{ matrix.fqbn }}
-         libraries: Arduino_DebugUtils WiFi101 WiFiNINA MKRGSM MKRNB
+         libraries: ${{ env.LIBRARIES }}
+     - name: compile-examples for ESP8266 boards
+       if: startsWith(matrix.fqbn, '"esp8266:esp8266')
+       uses: arduino/actions/libraries/compile-examples@master
+       with:
+         fqbn: ${{ matrix.fqbn }}
+         libraries: ${{ env.LIBRARIES }}
+         entrypoint: /github/workspace/.github/workflows/install-python-wrapper.sh

--- a/.github/workflows/install-python-wrapper.sh
+++ b/.github/workflows/install-python-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+# This script is used as an alternate entrypoint to allow installing Python 3 (a dependency of
+# the ESP8266 core for Arduino) in the Docker container used by the compile-examples action
+
+# Install Python 3
+apt-get update && apt-get install -y python3
+
+Run the standard entrypoint script
+/entrypoint.sh "$@"


### PR DESCRIPTION
The ESP8266 core for Arduino has Python 3 as a dependency. On Linux, instead of installing their own copy of Python 3, they assume it is already installed at `/usr/bin/python3` and only install a symlink to it. The Docker container used by the compile-examples action does not have Python 3 installed, so this required using a wrapper script as an alternate entrypoint when compiling for an ESP8266 board. The wrapper script installs Python 3 and then passes the arguments on to the standard entrypoint script.