### PR TITLE
Mark function 'update' as deprecated to be removed in a future release

### DIFF
--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -138,7 +138,7 @@ class ConnectionHandler {
   public:
     virtual void init() = 0;
     virtual void check() = 0;
-    virtual void update() = 0;
+    virtual void update() __attribute__((deprecated)) = 0; /* use 'check()' instead */
 
     #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB)
       virtual unsigned long getTime() = 0;

--- a/src/Arduino_GSMConnectionHandler.h
+++ b/src/Arduino_GSMConnectionHandler.h
@@ -40,7 +40,7 @@ class GSMConnectionHandler : public TcpIpConnectionHandler {
     virtual void check() {
       update();
     }
-    virtual void update();
+    virtual void update() __attribute__((deprecated)); /* use 'check()' instead */
     virtual Client &getClient() {
       return networkClient;
     };

--- a/src/Arduino_LPWANConnectionHandler.h
+++ b/src/Arduino_LPWANConnectionHandler.h
@@ -33,7 +33,7 @@ class LPWANConnectionHandler : public ConnectionHandler {
   public:
     virtual void init() = 0;
     virtual void check() = 0;
-    virtual void update() = 0;
+    virtual void update() __attribute__((deprecated)) = 0; /* use 'check()' instead */
     virtual unsigned long getTime() = 0;
 
     virtual int write(const uint8_t *buf, size_t size) = 0;

--- a/src/Arduino_LoRaConnectionHandler.h
+++ b/src/Arduino_LoRaConnectionHandler.h
@@ -49,7 +49,7 @@ class LoRaConnectionHandler : public LPWANConnectionHandler {
     void check() {
       update();
     }
-    void update();
+    void update() __attribute__((deprecated)); /* use 'check()' instead */
 
     int write(const uint8_t *buf, size_t size);
     int read();

--- a/src/Arduino_NBConnectionHandler.h
+++ b/src/Arduino_NBConnectionHandler.h
@@ -41,7 +41,7 @@ class NBConnectionHandler : public TcpIpConnectionHandler {
     virtual void check() {
       update();
     }
-    virtual void update();
+    virtual void update() __attribute__((deprecated)); /* use 'update()' instead */
     virtual Client &getClient() {
       return networkClient;
     };

--- a/src/Arduino_TcpIpConnectionHandler.h
+++ b/src/Arduino_TcpIpConnectionHandler.h
@@ -36,7 +36,7 @@ class TcpIpConnectionHandler : public ConnectionHandler {
   public:
     virtual void init() = 0;
     virtual void check() = 0;
-    virtual void update() = 0;
+    virtual void update() __attribute__((deprecated)) = 0; /* use 'update()' instead */
     virtual unsigned long getTime() = 0;
     virtual Client &getClient() = 0;
     virtual UDP &getUDP() = 0;

--- a/src/Arduino_WiFiConnectionHandler.h
+++ b/src/Arduino_WiFiConnectionHandler.h
@@ -39,7 +39,7 @@ class WiFiConnectionHandler : public TcpIpConnectionHandler {
     virtual void check() {
       update();
     }
-    virtual void update();
+    virtual void update() __attribute__((deprecated)); /* use 'update()' instead */
     virtual Client &getClient() {
       return wifiClient;
     };


### PR DESCRIPTION
`ArduinoIoTCloud` uses only `check` therefore is no need to keep the function `update` around - it just adds to the confusion and provides no real benefit.