### PR TITLE
Remove wrapper script previously required for ESP8266 CI build

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,16 +23,8 @@ jobs:
      - uses: actions/checkout@v1
        with:
          fetch-depth: 1
-     - name: compile-examples for official Arduino boards
-       if: startsWith(matrix.fqbn, '"esp8266:esp8266') != true
+     - name: Compile examples
        uses: arduino/actions/libraries/compile-examples@master
        with:
          fqbn: ${{ matrix.fqbn }}
          libraries: ${{ env.LIBRARIES }}
-     - name: compile-examples for ESP8266 boards
-       if: startsWith(matrix.fqbn, '"esp8266:esp8266')
-       uses: arduino/actions/libraries/compile-examples@master
-       with:
-         fqbn: ${{ matrix.fqbn }}
-         libraries: ${{ env.LIBRARIES }}
-         entrypoint: /github/workspace/.github/workflows/install-python-wrapper.sh

--- a/.github/workflows/install-python-wrapper.sh
+++ b/.github/workflows/install-python-wrapper.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -x
-# This script is used as an alternate entrypoint to allow installing Python 3 (a dependency of
-# the ESP8266 core for Arduino) in the Docker container used by the compile-examples action
-
-# Install Python 3
-apt-get update && apt-get install -y python3
-
-# Run the standard entrypoint script
-/entrypoint.sh "$@"


### PR DESCRIPTION
Previously, this script was needed to install the ESP8266 platform's Python dependency during the CI run. Since then, the `arduino/actions/libraries/compile-examples` action has been modified to install Python, so that is no longer necessary.