### PR TITLE
Report memory usage change caused by PRs

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,30 +1,30 @@
 name: Compile Examples
 on: [push, pull_request]
 jobs:
- build:
-   runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-latest
 
-   env:
-     LIBRARIES: Arduino_DebugUtils WiFi101 WiFiNINA MKRGSM MKRNB MKRWAN
-   strategy:
-     matrix:
-       fqbn: [
-         "arduino:samd:mkr1000",
-         "arduino:samd:mkrwifi1010",
-         "arduino:samd:nano_33_iot",
-         "arduino:samd:mkrgsm1400",
-         "arduino:samd:mkrnb1500",
-         "arduino:samd:mkrwan1300",
-         "arduino:samd:mkrwan1310",
-         '"esp8266:esp8266:huzzah" "https://arduino.esp8266.com/stable/package_esp8266com_index.json"'
-       ]
+    env:
+      LIBRARIES: Arduino_DebugUtils WiFi101 WiFiNINA MKRGSM MKRNB MKRWAN
+    strategy:
+      matrix:
+        fqbn: [
+          "arduino:samd:mkr1000",
+          "arduino:samd:mkrwifi1010",
+          "arduino:samd:nano_33_iot",
+          "arduino:samd:mkrgsm1400",
+          "arduino:samd:mkrnb1500",
+          "arduino:samd:mkrwan1300",
+          "arduino:samd:mkrwan1310",
+          '"esp8266:esp8266:huzzah" "https://arduino.esp8266.com/stable/package_esp8266com_index.json"'
+        ]
 
-   steps:
-     - uses: actions/checkout@v1
-       with:
-         fetch-depth: 1
-     - name: Compile examples
-       uses: arduino/actions/libraries/compile-examples@master
-       with:
-         fqbn: ${{ matrix.fqbn }}
-         libraries: ${{ env.LIBRARIES }}
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Compile examples
+        uses: arduino/actions/libraries/compile-examples@master
+        with:
+          fqbn: ${{ matrix.fqbn }}
+          libraries: ${{ env.LIBRARIES }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,8 +23,18 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
+
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:
           fqbn: ${{ matrix.fqbn }}
           libraries: ${{ env.LIBRARIES }}
+          size-report-sketch: 'ConnectionHandlerDemo'
+          enable-size-deltas-report: 'true'
+
+      - name: Save memory usage change report as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'size-deltas-reports'
+          path: 'size-deltas-reports'

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,13 @@
+name: Report PR Size Deltas
+
+on:
+  schedule:
+    - cron:  '*/5 * * * *'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/actions/libraries/report-size-deltas@master


### PR DESCRIPTION
On every push to a pull request, the change in memory usage of `examples/ConnectionHandlerDemo` between the PR's head and base branch for each of the boards in the board matrix will be:
- Shown in the log
- Saved to a workflow artifact (can be seen [here](https://github.com/arduino-libraries/Arduino_ConnectionHandler/pull/31/checks?check_run_id=595712256))
- Commented to the PR's thread as a table (after a delay of ~7 minutes max.)

---
Demo: https://github.com/per1234/Arduino_ConnectionHandler/pull/2#issuecomment-615291325