### PR TITLE
Only run Compile Examples workflow when relevant files are modified

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,5 +1,17 @@
 name: Compile Examples
-on: [push, pull_request]
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Running the Compile Examples GitHub Actions workflow is only necessary when files under `examples/`, `src/`, or the workflow configuration itself are modified. For any other changes, the workflow run only slows down the CI results and causes unnecessary comments from the `report-size-deltas` workflow.

Reference:
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths