### PR TITLE
[WIP] Add support for runtime configuration of network parameters

### DIFF
--- a/src/Arduino_GSMConnectionHandler.cpp
+++ b/src/Arduino_GSMConnectionHandler.cpp
@@ -68,10 +68,10 @@ unsigned long GSMConnectionHandler::getTime()
 
 NetworkConnectionState GSMConnectionHandler::update_handleInit()
 {
+  _gsm.setTimeout(GSM_TIMEOUT);
   if (_gsm.begin(_pin) == GSM_READY)
   {
     Debug.print(DBG_INFO, "SIM card ok");
-    _gsm.setTimeout(GSM_TIMEOUT);
     return NetworkConnectionState::CONNECTING;
   }
   else

--- a/src/Arduino_GSMConnectionHandler.cpp
+++ b/src/Arduino_GSMConnectionHandler.cpp
@@ -43,6 +43,16 @@ GSMConnectionHandler::GSMConnectionHandler(const char * pin, const char * apn, c
 
 }
 
+GSMConnectionHandler::GSMConnectionHandler(bool const keep_alive)
+: ConnectionHandler{keep_alive}
+, _pin("")
+, _apn("")
+, _login("")
+, _pass("")
+{
+
+}
+
 /******************************************************************************
    PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
@@ -109,6 +119,7 @@ NetworkConnectionState GSMConnectionHandler::update_handleConnected()
 
 NetworkConnectionState GSMConnectionHandler::update_handleDisconnecting()
 {
+  // _gsm.lowPowerMode();
   _gsm.shutdown();
   return NetworkConnectionState::DISCONNECTED;
 }

--- a/src/Arduino_GSMConnectionHandler.cpp
+++ b/src/Arduino_GSMConnectionHandler.cpp
@@ -119,7 +119,6 @@ NetworkConnectionState GSMConnectionHandler::update_handleConnected()
 
 NetworkConnectionState GSMConnectionHandler::update_handleDisconnecting()
 {
-  // _gsm.lowPowerMode();
   _gsm.shutdown();
   return NetworkConnectionState::DISCONNECTED;
 }

--- a/src/Arduino_GSMConnectionHandler.h
+++ b/src/Arduino_GSMConnectionHandler.h
@@ -36,7 +36,12 @@ class GSMConnectionHandler : public ConnectionHandler
   public:
 
     GSMConnectionHandler(const char * pin, const char * apn, const char * login, const char * pass, bool const keep_alive = true);
+    GSMConnectionHandler(bool const keep_alive = true);
 
+    void setSimPin(const char * pin) { _pin = pin; };
+    void setGprsApn(const char * apn) { _apn = apn; };
+    void setGprsUsername(const char * user) { _login = user; };
+    void setGprsPassword(const char * pass) { _pass = pass; };
 
     virtual unsigned long getTime() override;
     virtual Client & getClient() override { return _gsm_client; };


### PR DESCRIPTION
This PR is for adding support for configuration of network parameters (SSID/Username/Password for WiFi and APN/Username/Password for GSM/NB) at runtime, to allow the user to (re)configure these parameters after the Connection Handler has been constructed.