### PR TITLE
Bugfix: Don't break MKRGSM stack when ping fails.

### DIFF
--- a/src/Arduino_GSMConnectionHandler.cpp
+++ b/src/Arduino_GSMConnectionHandler.cpp
@@ -58,26 +58,25 @@ unsigned long GSMConnectionHandler::getTime()
 
 NetworkConnectionState GSMConnectionHandler::update_handleInit()
 {
-  if (_gsm.begin(_pin) == GSM_READY)
-  {
-    Debug.print(DBG_INFO, "SIM card ok");
-    _gsm.setTimeout(GSM_TIMEOUT);
-
-    GSM3_NetworkStatus_t const network_status = _gprs.attachGPRS(_apn, _login, _pass, true);
-    Debug.print(DBG_DEBUG, "GPRS.attachGPRS(): %d", network_status);
-    if (network_status == GSM3_NetworkStatus_t::ERROR)
-    {
-      Debug.print(DBG_ERROR, "GPRS attach failed");
-      Debug.print(DBG_ERROR, "Make sure the antenna is connected and reset your board.");
-      return NetworkConnectionState::ERROR;
-    }
-    return NetworkConnectionState::CONNECTING;
-  }
-  else
+  if (_gsm.begin(_pin) != GSM_READY)
   {
     Debug.print(DBG_ERROR, "SIM not present or wrong PIN");
     return NetworkConnectionState::ERROR;
   }
+
+  Debug.print(DBG_INFO, "SIM card ok");
+  _gsm.setTimeout(GSM_TIMEOUT);
+
+  GSM3_NetworkStatus_t const network_status = _gprs.attachGPRS(_apn, _login, _pass, true);
+  Debug.print(DBG_DEBUG, "GPRS.attachGPRS(): %d", network_status);
+  if (network_status == GSM3_NetworkStatus_t::ERROR)
+  {
+    Debug.print(DBG_ERROR, "GPRS attach failed");
+    Debug.print(DBG_ERROR, "Make sure the antenna is connected and reset your board.");
+    return NetworkConnectionState::ERROR;
+  }
+
+  return NetworkConnectionState::CONNECTING;
 }
 
 NetworkConnectionState GSMConnectionHandler::update_handleConnecting()

--- a/src/Arduino_GSMConnectionHandler.cpp
+++ b/src/Arduino_GSMConnectionHandler.cpp
@@ -62,6 +62,15 @@ NetworkConnectionState GSMConnectionHandler::update_handleInit()
   {
     Debug.print(DBG_INFO, "SIM card ok");
     _gsm.setTimeout(GSM_TIMEOUT);
+
+    GSM3_NetworkStatus_t const network_status = _gprs.attachGPRS(_apn, _login, _pass, true);
+    Debug.print(DBG_DEBUG, "GPRS.attachGPRS(): %d", network_status);
+    if (network_status == GSM3_NetworkStatus_t::ERROR)
+    {
+      Debug.print(DBG_ERROR, "GPRS attach failed");
+      Debug.print(DBG_ERROR, "Make sure the antenna is connected and reset your board.");
+      return NetworkConnectionState::ERROR;
+    }
     return NetworkConnectionState::CONNECTING;
   }
   else
@@ -73,14 +82,6 @@ NetworkConnectionState GSMConnectionHandler::update_handleInit()
 
 NetworkConnectionState GSMConnectionHandler::update_handleConnecting()
 {
-  GSM3_NetworkStatus_t const network_status = _gprs.attachGPRS(_apn, _login, _pass, true);
-  Debug.print(DBG_DEBUG, "GPRS.attachGPRS(): %d", network_status);
-  if (network_status == GSM3_NetworkStatus_t::ERROR)
-  {
-    Debug.print(DBG_ERROR, "GPRS attach failed");
-    Debug.print(DBG_ERROR, "Make sure the antenna is connected and reset your board.");
-    return NetworkConnectionState::ERROR;
-  }
   Debug.print(DBG_INFO, "Sending PING to outer space...");
   int const ping_result = _gprs.ping("time.arduino.cc");
   Debug.print(DBG_INFO, "GPRS.ping(): %d", ping_result);


### PR DESCRIPTION
Calling attachGPRS multiple times is not handled well by the MRK GSM/MKR GSM stack. But this is exactly what happens when the first call to ping fails. Consequently the attachGPRS part has been moved one state up so it will be only called once.