### PR TITLE
Support for Ethernet connections, e.g. via MKR ETH shield

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,6 +6,7 @@
 # Datatypes (KEYWORD1)
 ####################################################
 ConnectionHandler	KEYWORD1
+EthernetConnectionHandler	KEYWORD1
 WiFiConnectionHandler	KEYWORD1
 GSMConnectionHandler	KEYWORD1
 NBConnectionHandler	KEYWORD1

--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -113,6 +113,14 @@
   #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_REQUIRED
 #endif
 
+//#define ARDUINO_ETHERNET_SHIELD /* Uncomment this line if you want to use a ethernet shield via e.g. MKR ETH Shield */
+#if defined(ARDUINO_ETHERNET_SHIELD)
+  #include <SPI.h>
+  #include <Ethernet.h>
+
+  #define BOARD_HAS_ETHERNET
+#endif
+
 /******************************************************************************
    INCLUDES
  ******************************************************************************/
@@ -212,7 +220,9 @@ class ConnectionHandler {
                             _on_error_event_callback = NULL;
 };
 
-#if defined(BOARD_HAS_WIFI)
+#if defined(BOARD_HAS_ETHERNET)
+  #include "Arduino_EthernetConnectionHandler.h"
+#elif defined(BOARD_HAS_WIFI)
   #include "Arduino_WiFiConnectionHandler.h"
 #elif defined(BOARD_HAS_GSM)
   #include "Arduino_GSMConnectionHandler.h"

--- a/src/Arduino_EthernetConnectionHandler.cpp
+++ b/src/Arduino_EthernetConnectionHandler.cpp
@@ -1,0 +1,85 @@
+/*
+   This file is part of ArduinoIoTCloud.
+
+   Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+
+   This software is released under the GNU General Public License version 3,
+   which covers the main part of arduino-cli.
+   The terms of this license can be found at:
+   https://www.gnu.org/licenses/gpl-3.0.en.html
+
+   You can be released from the requirements of the above licenses by purchasing
+   a commercial license. Buying such a license is mandatory if you want to modify or
+   otherwise use the software for commercial activities involving the Arduino
+   software without disclosing the source code of your own applications. To purchase
+   a commercial license, send an email to license@arduino.cc.
+*/
+
+/******************************************************************************
+   INCLUDE
+ ******************************************************************************/
+
+#include "Arduino_EthernetConnectionHandler.h"
+
+#ifdef BOARD_HAS_ETHERNET /* Only compile if the board has ethernet */
+
+/******************************************************************************
+   CTOR/DTOR
+ ******************************************************************************/
+
+EthernetConnectionHandler::EthernetConnectionHandler(uint8_t * mac, bool const keep_alive)
+: ConnectionHandler{keep_alive}
+, _mac{mac}
+{
+
+}
+
+/******************************************************************************
+   PROTECTED MEMBER FUNCTIONS
+ ******************************************************************************/
+
+NetworkConnectionState EthernetConnectionHandler::update_handleInit()
+{
+  if (Ethernet.begin(const_cast<uint8_t *>(_mac)) == 0) {
+    Debug.print(DBG_ERROR, F("Failed to configure Ethernet using DHCP"));
+
+    if (Ethernet.hardwareStatus() == EthernetNoHardware) {
+        Debug.print(DBG_ERROR, F("Error, ethernet shield was not found."));
+        return NetworkConnectionState::ERROR;
+    }
+
+    if (Ethernet.linkStatus() == LinkOFF) {
+        Debug.print(DBG_ERROR, F("Error, ethernet cable is not connected."));
+        return NetworkConnectionState::ERROR;
+    }
+
+    return NetworkConnectionState::ERROR;
+  }
+
+  return NetworkConnectionState::CONNECTING;
+}
+
+NetworkConnectionState EthernetConnectionHandler::update_handleConnecting()
+{
+  return NetworkConnectionState::CONNECTED;
+}
+
+NetworkConnectionState EthernetConnectionHandler::update_handleConnected()
+{
+  if (Ethernet.linkStatus() == LinkON)
+    return NetworkConnectionState::CONNECTED;
+  else
+    return NetworkConnectionState::DISCONNECTED;
+}
+
+NetworkConnectionState EthernetConnectionHandler::update_handleDisconnecting()
+{
+  return NetworkConnectionState::DISCONNECTED;
+}
+
+NetworkConnectionState EthernetConnectionHandler::update_handleDisconnected()
+{
+  return NetworkConnectionState::INIT;
+}
+
+#endif /* #ifdef BOARD_HAS_ETHERNET */

--- a/src/Arduino_EthernetConnectionHandler.h
+++ b/src/Arduino_EthernetConnectionHandler.h
@@ -1,0 +1,64 @@
+/*
+   This file is part of ArduinoIoTCloud.
+
+   Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+
+   This software is released under the GNU General Public License version 3,
+   which covers the main part of arduino-cli.
+   The terms of this license can be found at:
+   https://www.gnu.org/licenses/gpl-3.0.en.html
+
+   You can be released from the requirements of the above licenses by purchasing
+   a commercial license. Buying such a license is mandatory if you want to modify or
+   otherwise use the software for commercial activities involving the Arduino
+   software without disclosing the source code of your own applications. To purchase
+   a commercial license, send an email to license@arduino.cc.
+*/
+
+#ifndef ARDUINO_ETHERNET_CONNECTION_HANDLER_H_
+#define ARDUINO_ETHERNET_CONNECTION_HANDLER_H_
+
+/******************************************************************************
+   INCLUDE
+ ******************************************************************************/
+
+#include "Arduino_ConnectionHandler.h"
+
+#ifdef BOARD_HAS_ETHERNET /* Only compile if the board has ethernet */
+
+/******************************************************************************
+   CLASS DECLARATION
+ ******************************************************************************/
+
+class EthernetConnectionHandler : public ConnectionHandler
+{
+  public:
+
+    EthernetConnectionHandler(uint8_t * mac, bool const keep_alive = true);
+
+
+    virtual unsigned long getTime() override { return 0; }
+    virtual Client & getClient() override{ return _eth_client; }
+    virtual UDP & getUDP() override { return _eth_udp; }
+
+
+  protected:
+
+    virtual NetworkConnectionState update_handleInit         () override;
+    virtual NetworkConnectionState update_handleConnecting   () override;
+    virtual NetworkConnectionState update_handleConnected    () override;
+    virtual NetworkConnectionState update_handleDisconnecting() override;
+    virtual NetworkConnectionState update_handleDisconnected () override;
+
+  private:
+
+    uint8_t const * _mac;
+
+    EthernetUDP _eth_udp;
+    EthernetClient _eth_client;
+
+};
+
+#endif /* #ifdef BOARD_HAS_ETHERNET */
+
+#endif /* ARDUINO_ETHERNET_CONNECTION_HANDLER_H_ */


### PR DESCRIPTION
Usage:
* Uncomment [this line](https://github.com/arduino-libraries/Arduino_ConnectionHandler/blob/ethernet/src/Arduino_ConnectionHandler.h#L116).
* Instantiate `Ethernet_ConnectionHandler` in `thing_properties.h`
```C++
byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
EthernetConnectionHandler ArduinoIoTPreferredConnection(mac);
```
* Pass to `ArduinoIoTCloud` (as usual)
```C++
ArduinoCloud.begin(ArduinoIoTPreferredConnection, "mqtts-sa.iot.oniudra.cc");
```
This should fix #40 .
@baqwas can you please test this one?