### PR TITLE
Update CI workflow to correctly install ArduinoCore-API in arduino:mbed core

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -81,11 +81,6 @@ jobs:
           # The arduino/actions/libraries/compile-examples action will install the platform from this path
           path: ${{ env.ARDUINOCORE_MBED_STAGING_PATH }}
 
-      - name: Remove ArduinoCore-API symlink from Arduino mbed-Enabled Boards platform
-        # This step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
-        if: matrix.board.platform-name == 'arduino:mbed'
-        run: rm "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino/api"
-
       - name: Checkout ArduinoCore-API
         # This step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
         if: matrix.board.platform-name == 'arduino:mbed'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -87,8 +87,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: arduino/ArduinoCore-API
-          # As specified at https://github.com/arduino/ArduinoCore-mbed/blob/master/README.md#installation
-          ref: namespace_arduino
           path: ${{ env.ARDUINOCORE_API_STAGING_PATH }}
 
       - name: Install ArduinoCore-API


### PR DESCRIPTION
Recent changes to the Arduino Mbed OS Boards platform core's handling of the `arduino/ArduinoCore-API` repository resulted in the need to adjus how the "Compile Examples" CI workflow installs it for those boards.

---
The symlink for ArduinoCore-API in the Mbed OS Boards core library has been removed (https://github.com/arduino/ArduinoCore-mbed/commit/ca397e88926c16ccfd7531f842a2d8f0971dcffc). This resulted in the step of the "Compile Examples" CI workflow that removes the now non-existent symlink to fail.

---
Previously, the `namespace_arduino` branch of ArduinoCore-API was used in the core library of the development version of
the Mbed OS Boards platform used in the "Compile Examples" CI workflow. The default branch of ArduinoCore-API is now the
latest and greatest version, so the `namespace_arduino` branch should no longer be used for the Mbed OS Boards platform's core library (https://github.com/arduino/ArduinoCore-mbed/commit/3c175d7e4df9bbd19d65b5285f163785f28d0fbc).