### PR TITLE
ESP32 support + example fix (AVR DebugUtils removal)

### DIFF
--- a/examples/ConnectionHandlerDemo/ConnectionHandlerDemo.ino
+++ b/examples/ConnectionHandlerDemo/ConnectionHandlerDemo.ino
@@ -34,9 +34,9 @@ void setup() {
   Serial.begin(9600);
   /* Give a few seconds for the Serial connection to be available */
   delay(4000);
-
+#ifndef __AVR__
   setDebugMessageLevel(DBG_INFO);
-
+#endif
   conMan.addCallback(NetworkConnectionEvent::CONNECTED, onNetworkConnect);
   conMan.addCallback(NetworkConnectionEvent::DISCONNECTED, onNetworkDisconnect);
   conMan.addCallback(NetworkConnectionEvent::ERROR, onNetworkError);

--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -114,6 +114,17 @@
   #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_REQUIRED
 #endif
 
+#if defined(ESP32)
+    #include <WiFi.h>
+    #include <WiFiUdp.h>
+    #define BOARD_HAS_WIFI
+    #define NETWORK_HARDWARE_ERROR WL_NO_SHIELD
+    #define NETWORK_IDLE_STATUS WL_IDLE_STATUS
+    #define NETWORK_CONNECTED WL_CONNECTED
+    #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_REQUIRED
+
+#endif
+
 /******************************************************************************
    INCLUDES
  ******************************************************************************/

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -41,7 +41,7 @@ WiFiConnectionHandler::WiFiConnectionHandler(char const * ssid, char const * pas
 
 unsigned long WiFiConnectionHandler::getTime()
 {
-#if !defined(BOARD_ESP8266)
+#if !defined(BOARD_ESP8266) && !defined(ESP32)
   return WiFi.getTime();
 #else
   return 0;
@@ -54,7 +54,7 @@ unsigned long WiFiConnectionHandler::getTime()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleInit()
 {
-#ifndef BOARD_ESP8266
+#if !defined(BOARD_ESP8266) && !defined(ESP32)
 #if !defined(__AVR__)
   Debug.print(DBG_INFO, F("WiFi.status(): %d"), WiFi.status());
 #endif
@@ -87,14 +87,14 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
   delay(300);
   WiFi.begin(_ssid, _pass);
   delay(1000);
-#endif /* ifndef BOARD_ESP8266 */
+#endif /* #if !defined(BOARD_ESP8266) && !defined(ESP32) */
 
   return NetworkConnectionState::CONNECTING;
 }
 
 NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
 {
-#ifndef BOARD_ESP8266
+#if !defined(BOARD_ESP8266) && !defined(ESP32)
   if (WiFi.status() != WL_CONNECTED)
   {
     WiFi.begin(_ssid, _pass);
@@ -114,7 +114,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
 #if !defined(__AVR__)
     Debug.print(DBG_INFO, F("Connected to \"%s\""), _ssid);
 #endif
-#ifdef BOARD_ESP8266
+#if defined(BOARD_ESP8266) || defined(ESP32)
   configTime(0, 0, "time.arduino.cc", "pool.ntp.org", "time.nist.gov");
 #endif
     return NetworkConnectionState::CONNECTED;
@@ -149,7 +149,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleDisconnecting()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleDisconnected()
 {
-#ifndef BOARD_ESP8266
+#if !defined(BOARD_ESP8266) && !defined(ESP32)
   WiFi.end();
 #endif /* ifndef BOARD_ESP8266 */
   if (_keep_alive)


### PR DESCRIPTION
This PR adds ConnectionHandler support for ESP32-based boards and fixes the demo example which was still calling `setDebugLevel()` although that was not enabled for MegaAVR