### PR TITLE
Pin esp8266:esp8266 platform version to 2.5.0 in CI builds

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -68,6 +68,7 @@ jobs:
               # Install ESP8266 platform via Boards Manager
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
+                version: 2.5.0
           - board:
               platform-name: esp32:esp32
             platforms: |


### PR DESCRIPTION
Previously, the most recent release of the ESP8266 boards platform (currently 2.7.4) was used in the "Compile Examples"
CI workflow. Arduino Create uses 2.5.0, so it's best to use that version for testing as well.