### PR TITLE
Adding 'mbed' as supported library to Arduino_ConnectionHandler library

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino Library for network connection management (WiFi, GSM, NB, [Ethe
 paragraph=Originally part of ArduinoIoTCloud
 category=Communication
 url=https://github.com/arduino-libraries/Arduino_ConnectionHandler
-architectures=samd,esp32,esp8266
+architectures=samd,esp32,esp8266,mbed
 depends=Arduino_DebugUtils, WiFi101, WiFiNINA, MKRGSM, MKRNB, MKRWAN


### PR DESCRIPTION
Note: We are already using it on Portenta H7.