### PR TITLE
Use modern API of `arduino/compile-sketches` action

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,7 +25,15 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      LIBRARIES: Arduino_DebugUtils WiFi101 WiFiNINA MKRGSM MKRNB MKRWAN
+      LIBRARIES: |
+        # Install the Arduino_ConnectionHandler library from the repository
+        - source-path: ./
+        - name: Arduino_DebugUtils
+        - name: WiFi101
+        - name: WiFiNINA
+        - name: MKRGSM
+        - name: MKRNB
+        - name: MKRWAN
       ARDUINOCORE_MBED_STAGING_PATH: extras/ArduinoCore-mbed
       ARDUINOCORE_API_STAGING_PATH: extras/ArduinoCore-API
       SKETCHES_REPORTS_PATH: sketches-reports
@@ -123,8 +131,7 @@ jobs:
           platforms: ${{ matrix.platforms }}
           fqbn: ${{ matrix.board.fqbn }}
           libraries: ${{ env.LIBRARIES }}
-          size-report-sketch: 'ConnectionHandlerDemo'
-          enable-size-deltas-report: 'true'
+          enable-deltas-report: 'true'
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact


### PR DESCRIPTION
The API of the `arduino/compile-sketches` GitHub Actions action used to compile the library's example sketches in the "Compile Examples" CI workflow has evolved over time. Although measures were taken to provide backwards compatibility for the old API, it turns out that the GitHub Actions behavior of creating environment variables for arbitrary input names relied upon for still recognizing the old inputs is not consistent across action types. It works fine for the Docker container action type originally used by `arduino/compile-sketches`, but not for the new "Composite Run Steps" action type we switched to (https://github.com/arduino/compile-sketches/pull/14).

This change resulted in sketch data deltas no longer being generated due to the workflow's use of the unsupported input name `enable-size-deltas-report` (which was changed to the more appropriate `enable-deltas-report` last year). This resulted in failed runs of the "Report Size Deltas" due to the reports not having the required deltas data.
Example:
https://github.com/arduino-libraries/Arduino_ConnectionHandler/runs/3918424017?check_suite_focus=true#step:3:17
```
Traceback (most recent call last):
  File "/reportsizedeltas/reportsizedeltas.py", line 737, in <module>
    main()  # pragma: no cover
  File "/reportsizedeltas/reportsizedeltas.py", line 32, in main
    report_size_deltas.report_size_deltas()
  File "/reportsizedeltas/reportsizedeltas.py", line 95, in report_size_deltas
    self.report_size_deltas_from_workflow_artifacts()
  File "/reportsizedeltas/reportsizedeltas.py", line 149, in report_size_deltas_from_workflow_artifacts
    sketches_reports = self.get_sketches_reports(artifact_folder_object=artifact_folder_object)
  File "/reportsizedeltas/reportsizedeltas.py", line 295, in get_sketches_reports
    not in report_data[self.ReportKeys.boards][0][self.ReportKeys.sizes][0])
KeyError: 'sizes'
```

The fix is simply to update to the new input name in the "Compile Examples" GitHub Actions workflow that uses the
`arduino/compile-sketches` action.

I also updated the contents of [the action's `libraries` input](https://github.com/arduino/compile-sketches#libraries) to the new YAML array style. This was not mandatory because there is still backwards compatibility for the old API in this case due to the input name not having changed, but only the data format. However, the old data format is deprecated so it's safest to update.

I also removed the no longer used `size-report-sketch` input. This input was removed at the time the action was changed to report on all compilations