### PR TITLE
ARDUINO_PORTENTA_H7_M4: Remove from supported build options

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -56,8 +56,6 @@ jobs:
             platform-name: arduino:samd
           - fqbn: "arduino:mbed:envie_m7"
             platform-name: arduino:mbed
-          - fqbn: "arduino:mbed:envie_m4"
-            platform-name: arduino:mbed
           - fqbn: "esp8266:esp8266:huzzah"
             platform-name: esp8266:esp8266
           - fqbn: "esp32:esp32:esp32"

--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -43,7 +43,7 @@
   #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_LATEST_VERSION
 #endif
 
-#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4) || defined(ARDUINO_NICLA_VISION)
+#if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_NICLA_VISION)
   #include <WiFi.h>
   #include <WiFiUdp.h>
 


### PR DESCRIPTION
As of now, even if the build is fine, the wifi module is not working on the M4.

Goal of this pr is to remove the portenta M4 core from the build to keep the code clean.

If and when the wifi module will work on the M4 i will re-add the core.