### PR TITLE
Use generic defines ARDUINO_ARCH_ESP8266 and ARDUINO_ARCH_ESP32

### DIFF
--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -74,38 +74,7 @@
   #define BOARD_HAS_LORA
 #endif
 
-#if    defined(ARDUINO_ESP8266_ESP12)    \
-    || defined(ESP8266)                  \
-    || defined(ESP8266_ESP01)            \
-    || defined(ESP8266_ESP13)            \
-    || defined(ESP8266_GENERIC)          \
-    || defined(ESP8266_ESPRESSO_LITE_V1) \
-    || defined(ESP8266_ESPRESSO_LITE_V2) \
-    || defined(ESP8266_PHOENIX_V1)       \
-    || defined(ESP8266_PHOENIX_V2)       \
-    || defined(ESP8266_NODEMCU)          \
-    || defined(MOD_WIFI_ESP8266)         \
-    || defined(ESP8266_THING)            \
-    || defined(ESP8266_THING_DEV)        \
-    || defined(ESP8266_ESP210)           \
-    || defined(ESP8266_WEMOS_D1MINI)     \
-    || defined(ESP8266_WEMOS_D1MINIPRO)  \
-    || defined(ESP8266_WEMOS_D1MINILITE) \
-    || defined(ESP8266_WEMOS_D1R1)       \
-    || defined(ESP8266_ESP12)            \
-    || defined(WIFINFO)                  \
-    || defined(ESP8266_ARDUINO)          \
-    || defined(GEN4_IOD)                 \
-    || defined(ESP8266_OAK)              \
-    || defined(WIFIDUINO_ESP8266)        \
-    || defined(AMPERKA_WIFI_SLOT)        \
-    || defined(ESP8266_WIO_LINK)         \
-    || defined(ESP8266_ESPECTRO_CORE)
-  
-  #define BOARD_ESP8266
-#endif
-
-#if defined(BOARD_ESP8266)
+#if defined(ARDUINO_ARCH_ESP8266)
   #include <ESP8266WiFi.h>
   #include <WiFiUdp.h>
 

--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -85,15 +85,15 @@
   #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_REQUIRED
 #endif
 
-#if defined(ESP32)
-    #include <WiFi.h>
-    #include <WiFiUdp.h>
-    #define BOARD_HAS_WIFI
-    #define NETWORK_HARDWARE_ERROR WL_NO_SHIELD
-    #define NETWORK_IDLE_STATUS WL_IDLE_STATUS
-    #define NETWORK_CONNECTED WL_CONNECTED
-    #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_REQUIRED
-
+#if defined(ARDUINO_ARCH_ESP32)
+  #include <WiFi.h>
+  #include <WiFiUdp.h>
+  
+  #define BOARD_HAS_WIFI
+  #define NETWORK_HARDWARE_ERROR WL_NO_SHIELD
+  #define NETWORK_IDLE_STATUS WL_IDLE_STATUS
+  #define NETWORK_CONNECTED WL_CONNECTED
+  #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_REQUIRED
 #endif
 
 /******************************************************************************

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -41,7 +41,7 @@ WiFiConnectionHandler::WiFiConnectionHandler(char const * ssid, char const * pas
 
 unsigned long WiFiConnectionHandler::getTime()
 {
-#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
   return WiFi.getTime();
 #else
   return 0;
@@ -54,7 +54,7 @@ unsigned long WiFiConnectionHandler::getTime()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleInit()
 {
-#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
 #if !defined(__AVR__)
   Debug.print(DBG_INFO, F("WiFi.status(): %d"), WiFi.status());
 #endif
@@ -87,19 +87,19 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
   delay(300);
   WiFi.begin(_ssid, _pass);
   delay(1000);
-#endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32) */
+#endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32) */
 
   return NetworkConnectionState::CONNECTING;
 }
 
 NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
 {
-#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
   if (WiFi.status() != WL_CONNECTED)
   {
     WiFi.begin(_ssid, _pass);
   }
-#endif /* ifndef ARDUINO_ARCH_ESP8266 */
+#endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32) */
 
   if (WiFi.status() != NETWORK_CONNECTED)
   {
@@ -114,7 +114,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
 #if !defined(__AVR__)
     Debug.print(DBG_INFO, F("Connected to \"%s\""), _ssid);
 #endif
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ESP32)
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   configTime(0, 0, "time.arduino.cc", "pool.ntp.org", "time.nist.gov");
 #endif
     return NetworkConnectionState::CONNECTED;
@@ -149,9 +149,9 @@ NetworkConnectionState WiFiConnectionHandler::update_handleDisconnecting()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleDisconnected()
 {
-#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
   WiFi.end();
-#endif /* ifndef ARDUINO_ARCH_ESP8266 */
+#endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32) */
   if (_keep_alive)
   {
     return NetworkConnectionState::INIT;

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -41,7 +41,7 @@ WiFiConnectionHandler::WiFiConnectionHandler(char const * ssid, char const * pas
 
 unsigned long WiFiConnectionHandler::getTime()
 {
-#if !defined(BOARD_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
   return WiFi.getTime();
 #else
   return 0;
@@ -54,7 +54,7 @@ unsigned long WiFiConnectionHandler::getTime()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleInit()
 {
-#if !defined(BOARD_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
 #if !defined(__AVR__)
   Debug.print(DBG_INFO, F("WiFi.status(): %d"), WiFi.status());
 #endif
@@ -87,19 +87,19 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
   delay(300);
   WiFi.begin(_ssid, _pass);
   delay(1000);
-#endif /* #if !defined(BOARD_ESP8266) && !defined(ESP32) */
+#endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32) */
 
   return NetworkConnectionState::CONNECTING;
 }
 
 NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
 {
-#if !defined(BOARD_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
   if (WiFi.status() != WL_CONNECTED)
   {
     WiFi.begin(_ssid, _pass);
   }
-#endif /* ifndef BOARD_ESP8266 */
+#endif /* ifndef ARDUINO_ARCH_ESP8266 */
 
   if (WiFi.status() != NETWORK_CONNECTED)
   {
@@ -114,7 +114,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
 #if !defined(__AVR__)
     Debug.print(DBG_INFO, F("Connected to \"%s\""), _ssid);
 #endif
-#if defined(BOARD_ESP8266) || defined(ESP32)
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ESP32)
   configTime(0, 0, "time.arduino.cc", "pool.ntp.org", "time.nist.gov");
 #endif
     return NetworkConnectionState::CONNECTED;
@@ -149,9 +149,9 @@ NetworkConnectionState WiFiConnectionHandler::update_handleDisconnecting()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleDisconnected()
 {
-#if !defined(BOARD_ESP8266) && !defined(ESP32)
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ESP32)
   WiFi.end();
-#endif /* ifndef BOARD_ESP8266 */
+#endif /* ifndef ARDUINO_ARCH_ESP8266 */
   if (_keep_alive)
   {
     return NetworkConnectionState::INIT;


### PR DESCRIPTION
Just a minor change to keep things tidy. Nothing has changed in terms of boards supported.