### PR TITLE
Minor: switch informative WiFi debug prints from ERROR to INFO

### DIFF
--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -132,7 +132,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleConnected()
     if (_keep_alive)
     {
 #if !defined(__AVR__)
-      Debug.print(DBG_ERROR, F("Attempting reconnection"));
+      Debug.print(DBG_INFO, F("Attempting reconnection"));
 #endif
     }
   

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -67,7 +67,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
     return NetworkConnectionState::ERROR;
   }
 #if !defined(__AVR__)
-  Debug.print(DBG_ERROR, F("Current WiFi Firmware: %s"), WiFi.firmwareVersion());
+  Debug.print(DBG_INFO, F("Current WiFi Firmware: %s"), WiFi.firmwareVersion());
 #endif
 
 #if defined(WIFI_FIRMWARE_VERSION_REQUIRED)
@@ -82,7 +82,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
 #endif
 
 #else
-  Debug.print(DBG_ERROR, F("WiFi status ESP: %d"), WiFi.status());
+  Debug.print(DBG_INFO, F("WiFi status ESP: %d"), WiFi.status());
   WiFi.disconnect();
   delay(300);
   WiFi.begin(_ssid, _pass);


### PR DESCRIPTION
Some debug prints in the WiFI connection handler are marked as `ERROR`, but the content of the string is not a real error, thought this prints can be disabled using `setDebugMessageLevel(-1);` i think it is better to move them to level `INFO`