### PR TITLE
LoRa: add retries if joinOTAA(...) fails

### DIFF
--- a/src/Arduino_LoRaConnectionHandler.cpp
+++ b/src/Arduino_LoRaConnectionHandler.cpp
@@ -124,8 +124,9 @@ NetworkConnectionState LoRaConnectionHandler::update_handleConnecting()
   bool const network_status = _modem.joinOTAA(_appeui, _appkey);
   if (network_status != true)
   {
-    Debug.print(DBG_ERROR, F("Something went wrong; are you indoor? Move near a window, then reset and retry."));
-    return NetworkConnectionState::ERROR;
+    Debug.print(DBG_ERROR, F("Connection to the network failed"));
+    Debug.print(DBG_INFO, F("Retrying in \"%d\" milliseconds"), CHECK_INTERVAL_TABLE[static_cast<unsigned int>(NetworkConnectionState::CONNECTING)]);
+    return NetworkConnectionState::INIT;
   }
   else
   {


### PR DESCRIPTION
Issue: user reported problems on multiple boards not connecting to the network and to ArduinoIoTCloud. The boards are printing the following message on the serial monitor:

`Something went wrong; are you indoor? Move near a window, then reset and retry.`

and after they start looping without doing nothing.

Proposed solution: This patch adds automatic retries if `joinOTAA(...)` fails, this is very similar to what we are doing in the `CONNECTING` state of `WiFiConnectionHandler` calling` WiFi.begin(...)` until board gets connected.

