### PR TITLE
ESP: WiFi: Fix (re)connection 

### DIFF
--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -155,7 +155,7 @@ typedef void (*OnNetworkEventCallback)();
 static unsigned int const CHECK_INTERVAL_TABLE[] =
 {
   /* INIT          */ 100,
-#if defined(ARDUINO_ARCH_ESP32)
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   /* CONNECTING    */ 2000,
 #else
   /* CONNECTING    */ 500,

--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -155,7 +155,11 @@ typedef void (*OnNetworkEventCallback)();
 static unsigned int const CHECK_INTERVAL_TABLE[] =
 {
   /* INIT          */ 100,
+#if defined(ARDUINO_ARCH_ESP32)
+  /* CONNECTING    */ 2000,
+#else
   /* CONNECTING    */ 500,
+#endif
   /* CONNECTED     */ 10000,
   /* DISCONNECTING */ 100,
   /* DISCONNECTED  */ 1000,

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -24,6 +24,15 @@
 #ifdef BOARD_HAS_WIFI /* Only compile if the board has WiFi */
 
 /******************************************************************************
+   CONSTANTS
+ ******************************************************************************/
+#if defined(ARDUINO_ARCH_ESP8266)
+static int const ESP_WIFI_CONNECTION_TIMEOUT = 3000;
+#elif defined(ARDUINO_ARCH_ESP32)
+static int const ESP_WIFI_CONNECTION_TIMEOUT = 1000;
+#endif
+
+/******************************************************************************
    CTOR/DTOR
  ******************************************************************************/
 
@@ -93,12 +102,14 @@ NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
   if (WiFi.status() != WL_CONNECTED)
   {
     WiFi.begin(_ssid, _pass);
-#if defined(ARDUINO_ARCH_ESP8266)
-    WiFi.waitForConnectResult();
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+    /* Wait connection otherwise board won't connect */
+    unsigned long start = millis();
+    while((WiFi.status() != WL_CONNECTED) && (millis() - start) < ESP_WIFI_CONNECTION_TIMEOUT) {
+      delay(100);
+    }
 #endif
-#if defined(ARDUINO_ARCH_ESP32)
-    WiFi.waitForConnectResult(1000);
-#endif
+
   }
 
   if (WiFi.status() != NETWORK_CONNECTED)

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -80,13 +80,8 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
     delay(5000);
   }
 #endif
-
 #else
-  Debug.print(DBG_INFO, F("WiFi status ESP: %d"), WiFi.status());
-  WiFi.disconnect();
-  delay(300);
-  WiFi.begin(_ssid, _pass);
-  delay(1000);
+  WiFi.mode(WIFI_STA);
 #endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32) */
 
   return NetworkConnectionState::CONNECTING;

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -90,12 +90,16 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
 {
-#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
   if (WiFi.status() != WL_CONNECTED)
   {
     WiFi.begin(_ssid, _pass);
+#if defined(ARDUINO_ARCH_ESP8266)
+    WiFi.waitForConnectResult();
+#endif
+#if defined(ARDUINO_ARCH_ESP32)
+    WiFi.waitForConnectResult(1000);
+#endif
   }
-#endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32) */
 
   if (WiFi.status() != NETWORK_CONNECTED)
   {

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -54,10 +54,11 @@ unsigned long WiFiConnectionHandler::getTime()
 
 NetworkConnectionState WiFiConnectionHandler::update_handleInit()
 {
-#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
 #if !defined(__AVR__)
   Debug.print(DBG_INFO, F("WiFi.status(): %d"), WiFi.status());
 #endif
+
+#if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
   if (WiFi.status() == NETWORK_HARDWARE_ERROR)
   {
 #if !defined(__AVR__)

--- a/src/Arduino_WiFiConnectionHandler.cpp
+++ b/src/Arduino_WiFiConnectionHandler.cpp
@@ -28,8 +28,6 @@
  ******************************************************************************/
 #if defined(ARDUINO_ARCH_ESP8266)
 static int const ESP_WIFI_CONNECTION_TIMEOUT = 3000;
-#elif defined(ARDUINO_ARCH_ESP32)
-static int const ESP_WIFI_CONNECTION_TIMEOUT = 1000;
 #endif
 
 /******************************************************************************
@@ -93,7 +91,6 @@ NetworkConnectionState WiFiConnectionHandler::update_handleInit()
 #else
   WiFi.mode(WIFI_STA);
 #endif /* #if !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32) */
-
   return NetworkConnectionState::CONNECTING;
 }
 
@@ -102,7 +99,7 @@ NetworkConnectionState WiFiConnectionHandler::update_handleConnecting()
   if (WiFi.status() != WL_CONNECTED)
   {
     WiFi.begin(_ssid, _pass);
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+#if defined(ARDUINO_ARCH_ESP8266)
     /* Wait connection otherwise board won't connect */
     unsigned long start = millis();
     while((WiFi.status() != WL_CONNECTED) && (millis() - start) < ESP_WIFI_CONNECTION_TIMEOUT) {


### PR DESCRIPTION
Issue 1: i've got 2 ESP8266 boards and they are not able to connect to my WiFi with the current implementation: it looks like this delay is not enough to get the board connected.

```
WiFi.begin(_ssid, _pass);
delay(1000);
```
Solution: delay until the board is connected with a maximum timeout of 3s

```
#if defined(ARDUINO_ARCH_ESP8266)
    /* Wait connection otherwise board won't connect */
    unsigned long start = millis();
    while((WiFi.status() != WL_CONNECTED) && (millis() - start) < ESP_WIFI_CONNECTION_TIMEOUT) {
      delay(100);
    }
#endif
```

Issue 2: both my ESP8266 and ESP32 board are not alway reconneting to WiFi if connection drops (power off WiFi from the router)

Solution: moving `WiFi.begin(_ssid, _pass);` in `CONNECTING` status with a proper retry delay solves the issue for both boards
