### PR TITLE
Add CatM1ConnectionHandler to support Portenta CAT.M1/NB IoT GNSS Shield

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -56,6 +56,8 @@ jobs:
             platform-name: arduino:samd
           - fqbn: "arduino:mbed:envie_m7"
             platform-name: arduino:mbed
+          - fqbn: "arduino:mbed_portenta:envie_m7"
+            platform-name: arduino:mbed_portenta
           - fqbn: "esp8266:esp8266:huzzah"
             platform-name: esp8266:esp8266
           - fqbn: "esp32:esp32:esp32"

--- a/examples/ConnectionHandlerDemo/ConnectionHandlerDemo.ino
+++ b/examples/ConnectionHandlerDemo/ConnectionHandlerDemo.ino
@@ -41,6 +41,8 @@ GSMConnectionHandler conMan(SECRET_APN, SECRET_PIN, SECRET_GSM_USER, SECRET_GSM_
 NBConnectionHandler conMan(SECRET_PIN);
 #elif defined(BOARD_HAS_LORA)
 LoRaConnectionHandler conMan(SECRET_APP_EUI, SECRET_APP_KEY);
+#elif defined(BOARD_HAS_CATM1_NBIOT)
+CatM1ConnectionHandler conMan(SECRET_APN, SECRET_PIN, SECRET_GSM_USER, SECRET_GSM_PASS);
 #endif
 
 void setup() {

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,6 +11,7 @@ GSMConnectionHandler	KEYWORD1
 NBConnectionHandler	KEYWORD1
 LoRaConnectionHandler	KEYWORD1
 EthernetConnectionHandler	KEYWORD1
+CatM1ConnectionHandler KEYWORD1
 
 ####################################################
 # Methods and Functions (KEYWORD2)

--- a/src/Arduino_CatM1ConnectionHandler.cpp
+++ b/src/Arduino_CatM1ConnectionHandler.cpp
@@ -1,0 +1,99 @@
+/*
+   This file is part of ArduinoIoTCloud.
+
+   Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+
+   This software is released under the GNU General Public License version 3,
+   which covers the main part of arduino-cli.
+   The terms of this license can be found at:
+   https://www.gnu.org/licenses/gpl-3.0.en.html
+
+   You can be released from the requirements of the above licenses by purchasing
+   a commercial license. Buying such a license is mandatory if you want to modify or
+   otherwise use the software for commercial activities involving the Arduino
+   software without disclosing the source code of your own applications. To purchase
+   a commercial license, send an email to license@arduino.cc.
+*/
+
+/******************************************************************************
+   INCLUDE
+ ******************************************************************************/
+
+#include "Arduino_CatM1ConnectionHandler.h"
+
+#ifdef BOARD_HAS_CATM1_NBIOT /* Only compile if the board has CatM1 BN-IoT */
+
+/******************************************************************************
+   CTOR/DTOR
+ ******************************************************************************/
+
+CatM1ConnectionHandler::CatM1ConnectionHandler(const char * pin, const char * apn, const char * login, const char * pass, RadioAccessTechnologyType rat, uint32_t band, bool const keep_alive)
+: ConnectionHandler{keep_alive, NetworkAdapter::GSM}
+, _pin(pin)
+, _apn(apn)
+, _login(login)
+, _pass(pass)
+, _rat(rat)
+, _band(band)
+{
+
+}
+
+/******************************************************************************
+   PUBLIC MEMBER FUNCTIONS
+ ******************************************************************************/
+
+unsigned long CatM1ConnectionHandler::getTime()
+{
+  return GSM.getTime();
+}
+
+/******************************************************************************
+   PROTECTED MEMBER FUNCTIONS
+ ******************************************************************************/
+
+NetworkConnectionState CatM1ConnectionHandler::update_handleInit()
+{
+  return NetworkConnectionState::CONNECTING;
+}
+
+NetworkConnectionState CatM1ConnectionHandler::update_handleConnecting()
+{
+  if(!GSM.begin(_pin, _apn, _login, _pass, _rat, _band))
+  {
+    Debug.print(DBG_ERROR, F("The board was not able to register to the network..."));
+    return NetworkConnectionState::ERROR;
+  }
+  Debug.print(DBG_INFO, F("Connected to Network"));
+  return NetworkConnectionState::CONNECTED;
+}
+
+NetworkConnectionState CatM1ConnectionHandler::update_handleConnected()
+{
+  int const is_gsm_access_alive = GSM.isConnected();
+  if (is_gsm_access_alive != 1)
+  {
+    return NetworkConnectionState::DISCONNECTED;
+  }
+  return NetworkConnectionState::CONNECTED;
+}
+
+NetworkConnectionState CatM1ConnectionHandler::update_handleDisconnecting()
+{
+  GSM.disconnect();
+  return NetworkConnectionState::DISCONNECTED;
+}
+
+NetworkConnectionState CatM1ConnectionHandler::update_handleDisconnected()
+{
+  if (_keep_alive)
+  {
+    return NetworkConnectionState::INIT;
+  }
+  else
+  {
+   return NetworkConnectionState::CLOSED;
+  }
+}
+
+#endif /* #ifdef BOARD_HAS_CATM1_NBIOT  */

--- a/src/Arduino_CatM1ConnectionHandler.h
+++ b/src/Arduino_CatM1ConnectionHandler.h
@@ -1,0 +1,71 @@
+/*
+   This file is part of ArduinoIoTCloud.
+
+   Copyright 2019 ARDUINO SA (http://www.arduino.cc/)
+
+   This software is released under the GNU General Public License version 3,
+   which covers the main part of arduino-cli.
+   The terms of this license can be found at:
+   https://www.gnu.org/licenses/gpl-3.0.en.html
+
+   You can be released from the requirements of the above licenses by purchasing
+   a commercial license. Buying such a license is mandatory if you want to modify or
+   otherwise use the software for commercial activities involving the Arduino
+   software without disclosing the source code of your own applications. To purchase
+   a commercial license, send an email to license@arduino.cc.
+*/
+
+#ifndef ARDUINO_CATM1_CONNECTION_HANDLER_H_
+#define ARDUINO_CATM1_CONNECTION_HANDLER_H_
+
+/******************************************************************************
+   INCLUDE
+ ******************************************************************************/
+
+#include "Arduino_ConnectionHandler.h"
+
+
+#ifdef BOARD_HAS_CATM1_NBIOT /* Only compile if the board has CatM1 BN-IoT */
+
+/******************************************************************************
+   CLASS DECLARATION
+ ******************************************************************************/
+
+class CatM1ConnectionHandler : public ConnectionHandler
+{
+  public:
+
+    CatM1ConnectionHandler(const char * pin, const char * apn, const char * login, const char * pass, RadioAccessTechnologyType rat = CATM1, uint32_t band = BAND_3 | BAND_20 | BAND_19, bool const keep_alive = true);
+
+
+    virtual unsigned long getTime() override;
+    virtual Client & getClient() override { return _gsm_client; };
+    virtual UDP & getUDP() override { return _gsm_udp; };
+
+
+  protected:
+
+    virtual NetworkConnectionState update_handleInit         () override;
+    virtual NetworkConnectionState update_handleConnecting   () override;
+    virtual NetworkConnectionState update_handleConnected    () override;
+    virtual NetworkConnectionState update_handleDisconnecting() override;
+    virtual NetworkConnectionState update_handleDisconnected () override;
+
+
+  private:
+
+    const char * _pin;
+    const char * _apn;
+    const char * _login;
+    const char * _pass;
+
+    RadioAccessTechnologyType _rat;
+    uint32_t _band;
+
+    GSMUDP _gsm_udp;
+    GSMClient _gsm_client;
+};
+
+#endif /* #ifdef BOARD_HAS_CATM1_NBIOT  */
+
+#endif /* #ifndef ARDUINO_CATM1_CONNECTION_HANDLER_H_ */

--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -18,6 +18,14 @@
 #ifndef ARDUINO_CONNECTION_HANDLER_H_
 #define ARDUINO_CONNECTION_HANDLER_H_
 
+/******************************************************************************
+   INCLUDES
+ ******************************************************************************/
+
+#if !defined(__AVR__)
+#  include <Arduino_DebugUtils.h>
+#endif
+
 #include <Arduino.h>
 
 #ifdef ARDUINO_SAMD_MKR1000
@@ -158,14 +166,6 @@
   #define NETWORK_IDLE_STATUS WL_IDLE_STATUS
   #define NETWORK_CONNECTED WL_CONNECTED
   #define WIFI_FIRMWARE_VERSION_REQUIRED WIFI_FIRMWARE_LATEST_VERSION
-#endif
-
-/******************************************************************************
-   INCLUDES
- ******************************************************************************/
-
-#if !defined(__AVR__)
-#  include <Arduino_DebugUtils.h>
 #endif
 
 /******************************************************************************

--- a/src/Arduino_ConnectionHandler.h
+++ b/src/Arduino_ConnectionHandler.h
@@ -48,9 +48,12 @@
   #include <WiFiUdp.h>
   #include <Ethernet.h>
   #include <PortentaEthernet.h>
+  #include <GSM.h>
 
   #define BOARD_HAS_WIFI
   #define BOARD_HAS_ETHERNET
+  #define BOARD_HAS_CATM1_NBIOT
+  #define BOARD_HAS_PORTENTA_CATM1_NBIOT_SHIELD
   #define BOARD_HAS_PORTENTA_VISION_SHIELD_ETHERNET
   #define NETWORK_HARDWARE_ERROR WL_NO_SHIELD
   #define NETWORK_IDLE_STATUS WL_IDLE_STATUS
@@ -190,7 +193,8 @@ enum class NetworkAdapter {
   ETHERNET,
   NB,
   GSM,
-  LORA
+  LORA,
+  CATM1
 };
 
 typedef void (*OnNetworkEventCallback)();
@@ -226,7 +230,7 @@ class ConnectionHandler {
 
     NetworkConnectionState check();
 
-    #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB) || defined(BOARD_HAS_ETHERNET)
+    #if defined(BOARD_HAS_WIFI) || defined(BOARD_HAS_GSM) || defined(BOARD_HAS_NB) || defined(BOARD_HAS_ETHERNET) || defined(BOARD_HAS_CATM1_NBIOT)
       virtual unsigned long getTime() = 0;
       virtual Client &getClient() = 0;
       virtual UDP &getUDP() = 0;
@@ -287,6 +291,10 @@ class ConnectionHandler {
 
 #if defined(BOARD_HAS_ETHERNET)
   #include "Arduino_EthernetConnectionHandler.h"
+#endif
+
+#if defined(BOARD_HAS_CATM1_NBIOT)
+  #include "Arduino_CatM1ConnectionHandler.h"
 #endif
 
 #endif /* CONNECTION_HANDLER_H_ */


### PR DESCRIPTION
This PR adds support for the `Portenta CAT.M1/NB IoT GNSS Shield`. The shield provides `CatM1` and `NB-IoT` connectivity in a very similar way the `SARA-R410M-02B` module of the `MKRNB1500` does.

Even if it was possible to reuse the already present `NBConnectionHandler` i preferred to create a new one to avoid messing up the `NBConnectionHandler` with too much `#ifdef`