### PR TITLE
Change maintainer to `Arduino <info@arduino.cc>`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino_ConnectionHandler
 version=0.8.1
 author=Ubi de Feo, Cristian Maglie, Andrea Catozzi, Alexander Entinger et al.
-maintainer=Arduino.cc
+maintainer=Arduino <info@arduino.cc>
 sentence=Arduino Library for network connection management (WiFi, GSM, NB, [Ethernet])
 paragraph=Originally part of ArduinoIoTCloud
 category=Communication


### PR DESCRIPTION
Maintainer is changed from `Arduino.cc` to `Arduino <info@arduino.cc>` within the `library.properties` file. 