### PR TITLE
fix: Notecard_ConnectionHandler Power Profile

### DIFF
--- a/src/NotecardConnectionHandler.cpp
+++ b/src/NotecardConnectionHandler.cpp
@@ -396,7 +396,7 @@ NetworkConnectionState NotecardConnectionHandler::update_handleInit()
   // for the Opta Wirelss Extension.
   if (NetworkConnectionState::INIT == result) {
     if (J *req = _notecard.newRequest("card.voltage")) {
-      JAddStringToObject(req, "mode", "lipo");
+      JAddStringToObject(req, "mode", "lic");
       JAddBoolToObject(req, "alert", true);
       JAddBoolToObject(req, "sync", true);
       JAddBoolToObject(req, "usb", true);


### PR DESCRIPTION
There is a bug in code that specifically targets the Wireless for Arduino Opta expansion. The battery backup on the device is a Lithium Ion Capacitor (LIC), but the Lithium Polymer (LiPo) profile was provided.

The Notecard will work correctly in this state, but it the LIC is designed to support lower voltages than a LiPo. The improvement provided here will allow the Notecard to remain powered for a longer duration.