### PR TITLE
GSMConnectionHandler stuck in ERROR state if connection lost

### DIFF
--- a/src/ConnectionHandlerInterface.cpp
+++ b/src/ConnectionHandlerInterface.cpp
@@ -78,7 +78,7 @@ NetworkConnectionState ConnectionHandler::updateConnectionState() {
     case NetworkConnectionState::CONNECTED:     next_net_connection_state = update_handleConnected    (); break;
     case NetworkConnectionState::DISCONNECTING: next_net_connection_state = update_handleDisconnecting(); break;
     case NetworkConnectionState::DISCONNECTED:  next_net_connection_state = update_handleDisconnected (); break;
-    case NetworkConnectionState::ERROR:                                                                   break;
+    case NetworkConnectionState::ERROR:         next_net_connection_state = update_handleError        (); break;
     case NetworkConnectionState::CLOSED:                                                                  break;
   }
 
@@ -86,6 +86,15 @@ NetworkConnectionState ConnectionHandler::updateConnectionState() {
   _current_net_connection_state = next_net_connection_state;
 
   return next_net_connection_state;
+}
+
+NetworkConnectionState ConnectionHandler::update_handleError()
+{
+  if (_keep_alive)  {
+    return NetworkConnectionState::INIT;
+  }
+
+  return NetworkConnectionState::ERROR;
 }
 
 void ConnectionHandler::updateCallback(NetworkConnectionState next_net_connection_state) {

--- a/src/ConnectionHandlerInterface.h
+++ b/src/ConnectionHandlerInterface.h
@@ -124,6 +124,7 @@ class ConnectionHandler {
     virtual NetworkConnectionState update_handleConnected    () = 0;
     virtual NetworkConnectionState update_handleDisconnecting() = 0;
     virtual NetworkConnectionState update_handleDisconnected () = 0;
+    virtual NetworkConnectionState update_handleError        ();
 
     models::NetworkSetting _settings;
 

--- a/src/GenericConnectionHandler.cpp
+++ b/src/GenericConnectionHandler.cpp
@@ -180,3 +180,7 @@ NetworkConnectionState GenericConnectionHandler::update_handleDisconnecting() {
 NetworkConnectionState GenericConnectionHandler::update_handleDisconnected() {
     return _ch != nullptr ? _ch->update_handleDisconnected() : NetworkConnectionState::INIT;
 }
+
+NetworkConnectionState GenericConnectionHandler::update_handleError() {
+    return _ch != nullptr ? _ch->update_handleError() : NetworkConnectionState::INIT;
+}

--- a/src/GenericConnectionHandler.h
+++ b/src/GenericConnectionHandler.h
@@ -69,6 +69,7 @@ class GenericConnectionHandler : public ConnectionHandler
     NetworkConnectionState update_handleConnected    () override;
     NetworkConnectionState update_handleDisconnecting() override;
     NetworkConnectionState update_handleDisconnected () override;
+    NetworkConnectionState update_handleError        () override;
 
   private:
 


### PR DESCRIPTION
This PR is probably related to #60 and #32 but it is more general IMO.

Whenever a `ConnectionHandler` enters the `NetworkConnectionState::ERROR` state it is stuck there, since the state machine does not handle it

In the case of `GSMConnectionHandler` specifically, when GSM connection is lost (eg no range), the state machine returns to `INIT` then calls `update_handleInit` but with `_gsm` having a `timeout = GSM_TIMEOUT` from the previous invokation.

If GSM is not restored in the `GSM_TIMEOUT` window the `GSMConnectionHandler` will enter the `ERROR `state forever

This fix attempts reinitialization if `_keep_alive` is set and the state machine is in `NetworkConnectionState::ERROR`

The issue was confirmed on a custom LTE modem module, but should be reproducible on boards using MKRGSM library (eg MKRGSM1400 which I don't have unfortunately) since the drivers are quite similar